### PR TITLE
small typo fixes

### DIFF
--- a/tutorials/1-overview.md
+++ b/tutorials/1-overview.md
@@ -153,7 +153,7 @@ Repeated patterns allow you to capture multiple instances of a pattern at a time
 
 A basic example: `rule { ($name ...) } => { $name ... }`. This matches all the syntax within the parentheses, and strips the parentheses in the output.
 
-A repeated pattern matches 0 or more times, so you can't use it enforce the existance of a pattern. In this sense, it will *always* match, even if the match is nothing.
+A repeated pattern matches 0 or more times, so you can't use it to enforce the existence of a pattern. In this sense, it will *always* match, even if the match is nothing.
 
 ```js
 macro basic {
@@ -212,7 +212,7 @@ var y = 11;</div>
 
 In the above example, The first 2 cases create 2 different variables because the macro itself created an `x` which is different than the `x` I made with `var`. In the last 2 cases, both reference the same `y` because I passed it in to the macro. 
 
-Hygienic renaming is the reason you see a variable like `foo` renamed to 'foo$1234'. sweet.js ensures that each variable is referencing the correct thing. It must rename all variables for reasons explain in [this post](http://disnetdev.com/blog/2013/09/27/hygiene-in-sweet.js/). Unfortunately that means all your identifiers become a little ugly, but if you pass the `-r` or "readable names" options to the sweet.js compiler, it will clean that up and most of it will be pretty again. That only works on ES5 code right now, which is why it's not on by default.
+Hygienic renaming is the reason you see a variable like `foo` renamed to 'foo$1234'. sweet.js ensures that each variable is referencing the correct thing. It must rename all variables for reasons explained in [this post](http://disnetdev.com/blog/2013/09/27/hygiene-in-sweet.js/). Unfortunately that means all your identifiers become a little ugly, but if you pass the `-r` or "readable names" options to the sweet.js compiler, it will clean that up and most of it will be pretty again. That only works on ES5 code right now, which is why it's not on by default.
 
 ## Using the sweet.js Compiler
 

--- a/tutorials/2-recurse-and-classes.md
+++ b/tutorials/2-recurse-and-classes.md
@@ -155,7 +155,7 @@ However, if you <a href="#var3" data-editor-change="rec1">remove the <code>var</
 
 Ideally our macro should expand to a single `var` statement like `var arr = expr, i = 0, x = arr[i++]` instead of multiple `var` statements. Our current macro won't work in `for` and `while` statements (`for(var [x, y] = arr; x<10; x++) {}`) because multiple statements are invalid there. Unfortunately, we would need to recursively invoke a macro in the `var` binding place but we can't do that as explained above. The macro would look like `var destruct_array arr i [ $pattern ... , END ]`, but you can't do that.
 
-Let's continue working on the destructuring macro and add support for nested destructuring. You should be able to do `var [x, [y, z]] = arr` but our macro doesn't handle that. Because we of recursive macros, it turns out to be really easy to add that. All we need to do is relax the accepted token type in `destruct_array` to accept anything (`$var:id` was changed to `$first`) and switch the order of macros.
+Let's continue working on the destructuring macro and add support for nested destructuring. You should be able to do `var [x, [y, z]] = arr` but our macro doesn't handle that. Because we have recursive macros, it turns out to be really easy to add that. All we need to do is relax the accepted token type in `destruct_array` to accept anything (`$var:id` was changed to `$first`) and switch the order of macros.
 
 <div class="macro-editor" id="var4">let var = macro {
   rule { [ $pattern ...] = $obj:expr } => {


### PR DESCRIPTION
it enforce the existance => it to enforce the existence
explain in => explained in
we of => we have

(These tutorials are great! I really enjoyed reading them.)
